### PR TITLE
Fix for dimension when it is decimal and onlayout gives a new dimensi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+.DS_Store
 *.ap_
 
 # Files for the ART/Dalvik VM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview-gridlayoutprovider",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.1",
   "description": "Grid Layout Provider built on top of RecyclerListView!",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview-gridlayoutprovider",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "description": "Grid Layout Provider built on top of RecyclerListView!",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/GridLayoutManager.ts
+++ b/src/GridLayoutManager.ts
@@ -28,6 +28,18 @@ export class GridLayoutManager extends WrapGridLayoutManager {
     }
   }
 
+  public overrideLayout(index: number, dim: Dimension): void {
+    const layout = this.getLayouts()[index];
+    if (layout) {
+      if (this._isGridHorizontal) {
+        dim.height = layout.height;
+      } else {
+        dim.width = layout.width;
+      }
+    }
+    super.overrideLayout(index, dim);
+  }
+
   public getStyleOverridesForIndex(index: number): object | undefined {
     const columnSpanForIndex = this._getSpan(index);
     return this._isGridHorizontal

--- a/src/GridLayoutManager.ts
+++ b/src/GridLayoutManager.ts
@@ -29,6 +29,11 @@ export class GridLayoutManager extends WrapGridLayoutManager {
   }
 
   public overrideLayout(index: number, dim: Dimension): void {
+    // we are doing this in case when we provide decimal dimensions for a
+    // certain cell and the onlayout returns a different dimension.
+    // This causes the layouting to behave weirdly.
+    // So, whenever we have layouts for a certain index, we explicitly override the dimension to those very layout values 
+    // and call super so as to set the overridden flag as true
     const layout = this.getLayouts()[index];
     if (layout) {
       if (this._isGridHorizontal) {

--- a/src/GridLayoutManager.ts
+++ b/src/GridLayoutManager.ts
@@ -29,10 +29,10 @@ export class GridLayoutManager extends WrapGridLayoutManager {
   }
 
   public overrideLayout(index: number, dim: Dimension): void {
-    // we are doing this in case when we provide decimal dimensions for a
-    // certain cell and the onlayout returns a different dimension.
-    // This causes the layouting to behave weirdly.
-    // So, whenever we have layouts for a certain index, we explicitly override the dimension to those very layout values 
+    // we are doing this because - when we provide decimal dimensions for a
+    // certain cell - the onlayout returns a different dimension in certain high end devices.
+    // This causes the layouting to behave weirdly as the new dimension might not adhere to the spans and the cells arrange themselves differently
+    // So, whenever we have layouts for a certain index, we explicitly override the dimension to those very layout values
     // and call super so as to set the overridden flag as true
     const layout = this.getLayouts()[index];
     if (layout) {


### PR DESCRIPTION
…on and hence the grid layout behaves weirdly

**Fix:**

Overriding dimension when we already have a layout for that index. Overriding height in case of horizontal and width in case of vertical.