### PR TITLE
feat: changing target and module to es6 with esModuleInterop flag on

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/muskeinsingh/recyclerlistview-gridlayoutmanager",
   "devDependencies": {
-    "recyclerlistview": "^3.0.1"
+    "recyclerlistview": "^3.0.0"
   },
   "peerDependencies": {
-    "recyclerlistview": "^3.0.1"
+    "recyclerlistview": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview-gridlayoutprovider",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Grid Layout Provider built on top of RecyclerListView!",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,9 +35,9 @@
   },
   "homepage": "https://github.com/muskeinsingh/recyclerlistview-gridlayoutmanager",
   "devDependencies": {
-    "recyclerlistview": "^2.0.0-beta.4"
+    "recyclerlistview": "^3.0.1"
   },
   "peerDependencies": {
-    "recyclerlistview": ">=2.0.0-beta.4"
+    "recyclerlistview": "^3.0.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
-    "lib": [
-      "es6",
-      "dom"
-    ], // target Node.js(v6)
-    "module": "commonjs", // export compatibility
-    "target": "es5", // target Node.js(v6)
+    "lib": ["es6", "dom"], // target Node.js(v6)
+    "module": "es6",
+    "target": "es6",
     "moduleResolution": "node", // target Node.js(v6)
     "declaration": true, // generate TypeScript definitions
     "rootDir": "src",


### PR DESCRIPTION
- the library is exported as commonJS which basically does not let the end user avail es6 benefits like tree shaking. hence, moving to target and module as `es6` 
- moving the `require` for `lodash/debounce` as `import` after the `esModuleInterop` flag is on